### PR TITLE
✨ Feature(AlreadySignedInPrompt): Given verify-email page now have 3 states, added new prompt to catch signed-in users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0](https://github.com/KemingHe/osuswe-app/compare/v0.5.8...v0.6.0) (2024-12-31)
+
+### Features
+
+* **components/verifyemail/:** added AlreadySignedInPrompt.tsx option to fixed verify email page ([2f40476](https://github.com/KemingHe/osuswe-app/commit/2f404760528b7f784707947154b7cece4e7c5808))
+
 ## [0.5.8](https://github.com/KemingHe/osuswe-app/compare/v0.5.7...v0.5.8) (2024-12-31)
 
 ### Bug Fixes

--- a/components/verifyEmail/AlreadySignedInPrompt.tsx
+++ b/components/verifyEmail/AlreadySignedInPrompt.tsx
@@ -1,0 +1,50 @@
+import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/16/solid';
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import type { JSX } from 'react';
+
+import {
+  AUTH_SIGN_OUT_ROUTE,
+  USER_DASHBOARD_ROUTE,
+} from '@/constants/routeConstants';
+
+export default function AlreadySignedInPrompt(): JSX.Element {
+  // NOTE: Width is manually set here to be consistent with SignInWirefram,
+  // refactor when ready.
+  return (
+    <div className="card w-72">
+      <figure className="pt-8">
+        <ExclamationCircleIcon className="size-14 text-success" />
+      </figure>
+      <div className="card-body items-center py-4 gap-4">
+        {/* NOTE: Current manual width setting breaks if using text-2xl or above. */}
+        <h2 className="card-title text-success">Already Signed In</h2>
+        <div className="card-actions gap-4">
+          <div className="w-full flex flex-col gap-2 text-sm leading-tight">
+            <p>If you are here by accident:</p>
+            <Link
+              href={USER_DASHBOARD_ROUTE}
+              className="btn btn-accent btn-sm w-full"
+            >
+              <ArrowLeftIcon className="size-4 -me-1.5" />
+              To dashboard
+            </Link>
+          </div>
+          <div className="w-full flex flex-col gap-2 text-sm leading-tight">
+            <p>
+              If you need to sign into or sign up with&nbsp;
+              <span className="font-bold">another account</span>:
+            </p>
+            <Link
+              href={AUTH_SIGN_OUT_ROUTE}
+              className="btn btn-error btn-outline btn-sm w-full"
+            >
+              To sign out
+              <ArrowRightIcon className="size-4 -ms-1.5" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/verifyEmail/VerificationFailurePrompt.tsx
+++ b/components/verifyEmail/VerificationFailurePrompt.tsx
@@ -5,17 +5,17 @@ import type { JSX } from 'react';
 
 import { AUTH_SIGN_IN_ROUTE } from '@/constants/routeConstants';
 
-export default function FailurePrompt(): JSX.Element {
+export default function VerificationFailurePrompt(): JSX.Element {
   // NOTE: Width is manually set here to be consistent with SignInWirefram,
   // refactor when ready.
   return (
     <div className="card w-72">
       <figure className="pt-8">
-        <ExclamationTriangleIcon className="size-14 text-warning" />
+        <ExclamationTriangleIcon className="size-14 text-error" />
       </figure>
       <div className="card-body items-center py-4 gap-4">
         {/* NOTE: Current manual width setting breaks if using text-2xl or above. */}
-        <h2 className="card-title text-warning">Verification Failed</h2>
+        <h2 className="card-title text-error">Verification Failed</h2>
         <div className="card-actions gap-4">
           <div className="flex flex-col gap-2 text-sm leading-tight">
             <p>Make sure to:</p>
@@ -39,7 +39,7 @@ export default function FailurePrompt(): JSX.Element {
           <div className="w-full">
             <Link
               href={AUTH_SIGN_IN_ROUTE}
-              className="btn btn-outline btn-sm w-full"
+              className="btn btn-accent btn-sm w-full"
             >
               Try again
               <ArrowRightIcon className="size-4 -ms-1.5" />

--- a/components/verifyEmail/VerifyEmailWrapper.tsx
+++ b/components/verifyEmail/VerifyEmailWrapper.tsx
@@ -7,7 +7,13 @@ import {
 import { VerifyEmailWireframe } from '@/components/verifyEmail/verifyEmailWireframe';
 
 export default function VerifyEmailWrapper(): JSX.Element {
-  const { isFailed }: UseVerifyEmailReturnProps = useVerifyEmail();
+  const { isAlreadySignedIn, isFailed }: UseVerifyEmailReturnProps =
+    useVerifyEmail();
 
-  return <VerifyEmailWireframe isFailed={isFailed} />;
+  return (
+    <VerifyEmailWireframe
+      isAlreadySignedIn={isAlreadySignedIn}
+      isFailed={isFailed}
+    />
+  );
 }

--- a/components/verifyEmail/verifyEmailWireframe.tsx
+++ b/components/verifyEmail/verifyEmailWireframe.tsx
@@ -1,23 +1,29 @@
 import type { JSX } from 'react';
 
 import { LoadingSpinner } from '@/components/loading/LoadingSpinner';
-import FailurePrompt from '@/components/verifyEmail/FailurePrompt';
+import AlreadySignedInPrompt from '@/components/verifyEmail/AlreadySignedInPrompt';
+import VerificationFailurePrompt from '@/components/verifyEmail/VerificationFailurePrompt';
 import { VERIFY_EMAIL_LOADING_MESSAGE } from '@/constants/loadingMessageConstants';
 
+// biome-ignore format: added alignment for clarity.
 export interface VerifyEmailWireframeProps {
-  isFailed: boolean;
+  isAlreadySignedIn: boolean;
+  isFailed         : boolean;
 }
 
 export function VerifyEmailWireframe({
+  isAlreadySignedIn,
   isFailed,
 }: VerifyEmailWireframeProps): JSX.Element {
+  const renderVerifyEmailComponent = (): JSX.Element => {
+    if (isAlreadySignedIn) return <AlreadySignedInPrompt />;
+    if (isFailed) return <VerificationFailurePrompt />;
+    return <LoadingSpinner message={VERIFY_EMAIL_LOADING_MESSAGE} />;
+  };
+
   return (
     <main className="w-full h-full flex flex-col justify-center items-center">
-      {isFailed ? (
-        <FailurePrompt />
-      ) : (
-        <LoadingSpinner message={VERIFY_EMAIL_LOADING_MESSAGE} />
-      )}
+      {renderVerifyEmailComponent()}
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "nextjs",
     "firebase"
   ],
-  "version": "0.5.8",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "author": {


### PR DESCRIPTION
If already signed in users try to access the verify-email page, with or without magic link code, they will be short-circuited to the `AlreadySignedInPrompt` for the following purposes:

1. Not verifying the code to prevent expiration.
2. Not failing the verification to prevent confusion.
3. Given the choice to be redir to either `dashboard` or `sign-out` so that `verify-email` page doesn't need to overextend its duties.