### PR TITLE
🐛 Fix(MainHero.tsx): Updated main hero action link from to-signin to to-dashboard for better UX

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm before node
-        # Pin to (v4) commit hash to protect against supply chain attacks. 
+        # Pinned to commit hash of release v4.0.0 on 05/07/24.
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-        # Omit with to use package.json packageManager field pnpm version
+        # Omit with to use package.json packageManager field pnpm version.
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up pnpm before node
-        # Pin to (v4) commit hash to protect against supply chain attacks. 
+        # Pinned to commit hash of release v4.0.0 on 05/07/24.
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-        # Omit with to use package.json packageManager field pnpm version
+        # Omit with to use package.json packageManager field pnpm version.
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.4](https://github.com/KemingHe/osuswe-app/compare/v0.9.3...v0.9.4) (2025-01-06)
+
+### Bug Fixes
+
+* **mainhero.tsx:** replaced main action link with to sign-in instead of to-dashboard, updated aria ([c59ac61](https://github.com/KemingHe/osuswe-app/commit/c59ac61c5d470726af89391d76c9f7eb3b7bd105))
+
 ## [0.9.3](https://github.com/KemingHe/osuswe-app/compare/v0.9.2...v0.9.3) (2025-01-04)
 
 ### Bug Fixes

--- a/components/homepage/main/MainHero.tsx
+++ b/components/homepage/main/MainHero.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import type { JSX } from 'react';
 
 import { DEVELOPER_LINKEDIN_LINK } from '@/constants/externalLinkConstants';
-import { USER_DASHBOARD_ROUTE } from '@/constants/routeConstants';
+import { AUTH_SIGN_IN_ROUTE } from '@/constants/routeConstants';
 
 export default function MainHero(): JSX.Element {
   return (
@@ -17,9 +17,9 @@ export default function MainHero(): JSX.Element {
         priority={true}
       />
       <Link
-        href={USER_DASHBOARD_ROUTE}
+        href={AUTH_SIGN_IN_ROUTE}
         className="btn btn-lg btn-accent shadow-md"
-        aria-label="Go to user dashboard"
+        aria-label="Go to sign in page"
       >
         Get Started
         <ArrowRightIcon className="size-4 -ms-1" aria-hidden="true" />

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "nextjs",
     "firebase"
   ],
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "type": "module",
   "author": {


### PR DESCRIPTION
...when first-time users "go back" from sign-in page, they will not be stuck in a redir loop. The will originally since the main action link (to-dashboard) with first take them to dashboard and then auto-redir to sign-in. 